### PR TITLE
fix(charset): union with central overlap

### DIFF
--- a/src/charset.test.ts
+++ b/src/charset.test.ts
@@ -51,6 +51,14 @@ test('union', () => {
   ).toEqual('[\\u0001\\u0003]');
 });
 
+test('union: central overlap', () => {
+  expect(
+    charset([0x5b, 0x60])
+      .union([0x5c, 0x5d])
+      .toString(),
+  ).toEqual(`[\\u005b-\\u0060]`);
+});
+
 test('subtract: front + no overlap', () => {
   expect(
     charset([5, 7])

--- a/src/charset.ts
+++ b/src/charset.ts
@@ -112,7 +112,10 @@ export class Charset extends Base {
         new_data.push(data_unit);
         last_data_unit = data_unit;
       } else {
-        new_data.splice(-1, 1, [last_data_unit[0], data_unit[1]]);
+        new_data.splice(-1, 1, [
+          Math.min(data_unit[0], last_data_unit[0]),
+          Math.max(data_unit[1], last_data_unit[1]),
+        ]);
         last_data_unit = new_data[new_data.length - 1];
       }
     }


### PR DESCRIPTION
before

```js
charset([0x5b, 0x60])
  .union([0x5c, 0x5d])
  .toString() //=> \u005b-\u005d
```

after

```js
charset([0x5b, 0x60])
  .union([0x5c, 0x5d])
  .toString() //=> \u005b-\u0060
```